### PR TITLE
NOJIRA - Add request handler spec

### DIFF
--- a/app/api/controllers/RequestContext.scala
+++ b/app/api/controllers/RequestContext.scala
@@ -19,7 +19,12 @@ package api.controllers
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.IdGenerator
 
-case class RequestContext(hc: HeaderCarrier, correlationId: String, endpointLogContext: EndpointLogContext)
+case class RequestContext(hc: HeaderCarrier, correlationId: String, endpointLogContext: EndpointLogContext) {
+
+  def withCorrelationId(correlationId: String): RequestContext =
+    copy(correlationId = correlationId)
+
+}
 
 object RequestContext {
 

--- a/app/api/models/audit/GenericAuditDetail.scala
+++ b/app/api/models/audit/GenericAuditDetail.scala
@@ -18,38 +18,41 @@ package api.models.audit
 
 import api.models.auth.UserDetails
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{JsPath, OWrites}
+import play.api.libs.json.{JsPath, JsValue, OWrites}
 
-case class GenericAuditDetail(
-    userType: String,
-    agentReferenceNumber: Option[String],
-    nino: String,
-    taxYear: String,
-    `X-CorrelationId`: String,
-    auditResponse: AuditResponse
-)
+case class GenericAuditDetail(userType: String,
+                              agentReferenceNumber: Option[String],
+                              params: Map[String, String],
+                              requestBody: Option[JsValue],
+                              `X-CorrelationId`: String,
+                              auditResponse: AuditResponse)
 
 object GenericAuditDetail {
 
   implicit val writes: OWrites[GenericAuditDetail] = (
     (JsPath \ "userType").write[String] and
       (JsPath \ "agentReferenceNumber").writeNullable[String] and
-      (JsPath \ "nino").write[String] and
-      (JsPath \ "taxYear").write[String] and
+      JsPath.write[Map[String, String]] and
+      (JsPath \ "request").writeNullable[JsValue] and
       (JsPath \ "X-CorrelationId").write[String] and
       (JsPath \ "response").write[AuditResponse]
-  )(unlift(GenericAuditDetail.unapply))
+    )(unlift(GenericAuditDetail.unapply))
 
-  def apply(userDetails: UserDetails, nino: String, taxYear: String, `X-CorrelationId`: String, auditResponse: AuditResponse): GenericAuditDetail = {
+  def apply(userDetails: UserDetails,
+            params: Map[String, String],
+            requestBody: Option[JsValue],
+            `X-CorrelationId`: String,
+            auditResponse: AuditResponse): GenericAuditDetail = {
 
     GenericAuditDetail(
       userType = userDetails.userType,
       agentReferenceNumber = userDetails.agentReferenceNumber,
-      nino = nino,
-      taxYear = taxYear,
+      params = params,
+      requestBody = requestBody,
       `X-CorrelationId` = `X-CorrelationId`,
       auditResponse = auditResponse
     )
   }
 
 }
+

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -33,7 +33,7 @@ object CodeCoverageSettings {
 
   val settings: Seq[Setting[_]] = Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimumStmtTotal := 92.5,
+    ScoverageKeys.coverageMinimumStmtTotal := 95,
     ScoverageKeys.coverageFailOnMinimum    := true,
     ScoverageKeys.coverageHighlighting     := true
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,9 +18,9 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.15")
 

--- a/test/api/controllers/RequestHandlerSpec.scala
+++ b/test/api/controllers/RequestHandlerSpec.scala
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api.controllers
+
+import api.mocks.MockIdGenerator
+import api.mocks.services.MockAuditService
+import api.models.audit.{AuditError, AuditEvent, AuditResponse, GenericAuditDetail}
+import api.models.auth.UserDetails
+import api.models.errors.{ErrorWrapper, NinoFormatError}
+import api.models.outcomes.ResponseWrapper
+import api.models.request.RawData
+import org.scalamock.handlers.CallHandler
+import play.api.http.{HeaderNames, Status}
+import play.api.libs.json.{JsString, Json, OWrites}
+import play.api.mvc.AnyContent
+import play.api.test.{FakeRequest, ResultExtractors}
+import support.UnitSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.AuditResult
+import v2.controllers.requestParsers.RequestParser
+import v2.services.ServiceOutcome
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class RequestHandlerSpec extends UnitSpec with MockAuditService with MockIdGenerator with Status with HeaderNames with ResultExtractors {
+
+  private val successResponseJson = Json.obj("result" -> "SUCCESS!")
+  private val successCode         = Status.ACCEPTED
+
+  private val generatedCorrelationId = "generatedCorrelationId"
+  private val serviceCorrelationId   = "serviceCorrelationId"
+
+  case object InputRaw extends RawData
+  case object Input
+  case object Output { implicit val writes: OWrites[Output.type] = _ => successResponseJson }
+
+  MockIdGenerator.generateCorrelationId.returns(generatedCorrelationId).anyNumberOfTimes()
+
+  implicit val endpointLogContext: EndpointLogContext =
+    EndpointLogContext(controllerName = "SomeController", endpointName = "someEndpoint")
+
+  implicit val hc: HeaderCarrier                    = HeaderCarrier()
+  implicit val ctx: RequestContext                  = RequestContext.from(mockIdGenerator, endpointLogContext)
+  private val userDetails                           = UserDetails("mtdId", "Individual", Some("agentReferenceNumber"))
+  implicit val userRequest: UserRequest[AnyContent] = UserRequest[AnyContent](userDetails, FakeRequest())
+
+  trait DummyService {
+    def service(input: Input.type)(implicit ctx: RequestContext, ec: ExecutionContext): Future[ServiceOutcome[Output.type]]
+  }
+
+  private val mockService = mock[DummyService]
+
+  private def service =
+    (mockService.service(_: Input.type)(_: RequestContext, _: ExecutionContext)).expects(Input, *, *)
+
+  private val mockParser = mock[RequestParser[InputRaw.type, Input.type]]
+
+  private def parseRequest =
+    (mockParser.parseRequest(_: InputRaw.type)(_: String)).expects(InputRaw, *)
+
+  "RequestHandler" when {
+    "a request is successful" must {
+      "return the correct response" in {
+        val requestHandler = RequestHandler
+          .withParser(mockParser)
+          .withService(mockService.service)
+          .withPlainJsonResult(successCode)
+
+        parseRequest returns Right(Input)
+        service returns Future.successful(Right(ResponseWrapper(serviceCorrelationId, Output)))
+
+        val result = requestHandler.handleRequest(InputRaw)
+
+        contentAsJson(result) shouldBe successResponseJson
+        header("X-CorrelationId", result) shouldBe Some(serviceCorrelationId)
+        status(result) shouldBe successCode
+      }
+
+      "return no content if required" in {
+        val requestHandler = RequestHandler
+          .withParser(mockParser)
+          .withService(mockService.service)
+          .withNoContentResult()
+
+        parseRequest returns Right(Input)
+        service returns Future.successful(Right(ResponseWrapper(serviceCorrelationId, Output)))
+
+        val result = requestHandler.handleRequest(InputRaw)
+
+        contentAsString(result) shouldBe ""
+        header("X-CorrelationId", result) shouldBe Some(serviceCorrelationId)
+        status(result) shouldBe NO_CONTENT
+      }
+
+    }
+
+    "a request fails with validation errors" must {
+      "return the errors" in {
+        val requestHandler = RequestHandler
+          .withParser(mockParser)
+          .withService(mockService.service)
+          .withPlainJsonResult(successCode)
+
+        parseRequest returns Left(ErrorWrapper(generatedCorrelationId, NinoFormatError))
+
+        val result = requestHandler.handleRequest(InputRaw)
+
+        contentAsJson(result) shouldBe NinoFormatError.asJson
+        header("X-CorrelationId", result) shouldBe Some(generatedCorrelationId)
+        status(result) shouldBe NinoFormatError.httpStatus
+      }
+    }
+
+    "a request fails with service errors" must {
+      "return the errors" in {
+        val requestHandler = RequestHandler
+          .withParser(mockParser)
+          .withService(mockService.service)
+          .withPlainJsonResult(successCode)
+
+        parseRequest returns Right(Input)
+        service returns Future.successful(Left(ErrorWrapper(serviceCorrelationId, NinoFormatError)))
+
+        val result = requestHandler.handleRequest(InputRaw)
+
+        contentAsJson(result) shouldBe NinoFormatError.asJson
+        header("X-CorrelationId", result) shouldBe Some(serviceCorrelationId)
+        status(result) shouldBe NinoFormatError.httpStatus
+      }
+    }
+
+    "auditing is configured" when {
+      val params = Map("param" -> "value")
+
+      val auditType = "type"
+      val txName    = "txName"
+
+      val requestBody = Some(JsString("REQUEST BODY"))
+
+      def auditHandler(includeResponse: Boolean = false): AuditHandler = AuditHandler(
+        mockAuditService,
+        auditType = auditType,
+        transactionName = txName,
+        params = params,
+        requestBody = requestBody,
+        includeResponse = includeResponse
+      )
+
+      val basicRequestHandler = RequestHandler
+        .withParser(mockParser)
+        .withService(mockService.service)
+        .withPlainJsonResult(successCode)
+
+      def verifyAudit(correlationId: String, auditResponse: AuditResponse): CallHandler[Future[AuditResult]] =
+        MockedAuditService.verifyAuditEvent(
+          AuditEvent(
+            auditType = auditType,
+            transactionName = txName,
+            GenericAuditDetail(userDetails, params = params, requestBody = requestBody, `X-CorrelationId` = correlationId, auditResponse)
+          ))
+
+      "a request is successful" when {
+        "no response is to be audited" must {
+          "audit without the response" in {
+            val requestHandler = basicRequestHandler.withAuditing(auditHandler())
+
+            parseRequest returns Right(Input)
+            service returns Future.successful(Right(ResponseWrapper(serviceCorrelationId, Output)))
+
+            val result = requestHandler.handleRequest(InputRaw)
+
+            contentAsJson(result) shouldBe successResponseJson
+            header("X-CorrelationId", result) shouldBe Some(serviceCorrelationId)
+            status(result) shouldBe successCode
+
+            verifyAudit(serviceCorrelationId, AuditResponse(successCode, Right(None)))
+          }
+        }
+
+        "the response is to be audited" must {
+          "audit with the response" in {
+            val requestHandler = basicRequestHandler.withAuditing(auditHandler(includeResponse = true))
+
+            parseRequest returns Right(Input)
+            service returns Future.successful(Right(ResponseWrapper(serviceCorrelationId, Output)))
+
+            val result = requestHandler.handleRequest(InputRaw)
+
+            contentAsJson(result) shouldBe successResponseJson
+            header("X-CorrelationId", result) shouldBe Some(serviceCorrelationId)
+            status(result) shouldBe successCode
+
+            verifyAudit(serviceCorrelationId, AuditResponse(successCode, Right(Some(successResponseJson))))
+          }
+        }
+      }
+
+      "a request fails with validation errors" must {
+        "audit the failure" in {
+          val requestHandler = basicRequestHandler.withAuditing(auditHandler())
+
+          parseRequest returns Left(ErrorWrapper(generatedCorrelationId, NinoFormatError))
+
+          val result = requestHandler.handleRequest(InputRaw)
+
+          contentAsJson(result) shouldBe NinoFormatError.asJson
+          header("X-CorrelationId", result) shouldBe Some(generatedCorrelationId)
+          status(result) shouldBe NinoFormatError.httpStatus
+
+          verifyAudit(generatedCorrelationId, AuditResponse(NinoFormatError.httpStatus, Left(Seq(AuditError(NinoFormatError.code)))))
+        }
+      }
+
+      "a request fails with service errors" must {
+        "audit the failure" in {
+          val requestHandler = basicRequestHandler.withAuditing(auditHandler())
+
+          parseRequest returns Right(Input)
+          service returns Future.successful(Left(ErrorWrapper(serviceCorrelationId, NinoFormatError)))
+
+          val result = requestHandler.handleRequest(InputRaw)
+
+          contentAsJson(result) shouldBe NinoFormatError.asJson
+          header("X-CorrelationId", result) shouldBe Some(serviceCorrelationId)
+          status(result) shouldBe NinoFormatError.httpStatus
+
+          verifyAudit(serviceCorrelationId, AuditResponse(NinoFormatError.httpStatus, Left(Seq(AuditError(NinoFormatError.code)))))
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Note that auditing is not actually used by any endpoints but GenericAuditDetail has been updated to a version that works better with the RequestHandler & RequestHandlerSpec